### PR TITLE
fix: Use dynamic API URL in frontend

### DIFF
--- a/js/ai-design-simple.js
+++ b/js/ai-design-simple.js
@@ -107,7 +107,7 @@ document.addEventListener('DOMContentLoaded', () => {
     async function callAIAPI(prompt) {
     // Allow overriding API base via window.KHADOCK_API_BASE if provided
     const base = (window && window.KHADOCK_API_BASE) ? window.KHADOCK_API_BASE : "http://localhost:3001";
-    const apiUrl = "https://khadock-ai-server.onrender.com/api/ai-design";
+    const apiUrl = `${base}/api/ai-design`;
 
         try {
             let response = await fetch(apiUrl, {


### PR DESCRIPTION
The API URL in `js/ai-design-simple.js` was hardcoded to a production URL, which prevented local development and testing.

This commit replaces the hardcoded URL with a dynamic one that defaults to `http://localhost:3001` but can be overridden by the `window.KHADOCK_API_BASE` variable. This allows the frontend to be easily pointed to a local server for development and testing.